### PR TITLE
Drop inotifywait  --include

### DIFF
--- a/wayland-launch/bin/wayland-launch
+++ b/wayland-launch/bin/wayland-launch
@@ -20,7 +20,7 @@ wait_for()
 {
   until
     until
-      inotifywait --event create "$(dirname "$1")" --include "$(basename "$1")"&
+      inotifywait --event create "$(dirname "$1")"&
       inotify_pid=$!
       [ -e "$1" ] || sleep 2 && [ -e "$1" ]
     do


### PR DESCRIPTION
On  `base: core20` `--include` doesn't work with inotifyway.

Dropping it will lead to more wakes than necessary, but should still work